### PR TITLE
fix: AMapGeolocationPackage不是抽象的

### DIFF
--- a/lib/android/src/main/java/cn/qiuxiang/react/geolocation/AMapGeolocationPackage.java
+++ b/lib/android/src/main/java/cn/qiuxiang/react/geolocation/AMapGeolocationPackage.java
@@ -4,6 +4,7 @@ import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -18,5 +19,10 @@ public class AMapGeolocationPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(new AMapGeolocationModule(reactContext));
+    }
+    
+    @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
修复 AMapGeolocationPackage不是抽象的

问题：安卓运行报错误: AMapGeolocationPackage不是抽象的, 并且未覆盖ReactPackage中的抽象方法createJSModules()
问题链接：https://github.com/qiuxiang/react-native-amap-geolocation/issues/114