### PR TITLE
解决 [UIApplication applicationState] must be used from main thread only

### DIFF
--- a/lib/ios/AMapGeolocation.m
+++ b/lib/ios/AMapGeolocation.m
@@ -16,12 +16,14 @@ RCT_REMAP_METHOD(init, initWithKey
                  : (NSString *)key
                  : (RCTPromiseResolveBlock)resolve
                  : (RCTPromiseRejectBlock)reject) {
-  [AMapServices sharedServices].apiKey = key;
-  if (!_manager) {
-    _manager = [AMapLocationManager new];
-    _manager.delegate = self;
-  }
-  resolve(nil);
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [AMapServices sharedServices].apiKey = key;
+      if (!(self->_manager)) {
+        self->_manager = [[AMapLocationManager alloc] init];
+        self->_manager.delegate = self;
+      }
+      resolve(nil);
+  });
 }
 
 RCT_EXPORT_METHOD(start) { [_manager startUpdatingLocation]; }


### PR DESCRIPTION
在 Xcode 11 下编译会导致 iOS 13 [的设备闪退。

问题是：`[UIApplication applicationState] must be used from main thread only`

![issue](https://res.hualala.com/group2/M02/07/A7/wKgVT15d3IWvrS59AAOHXL5K1xo835.jpg)

需要配合使用高德 [SDK2.6.4](https://lbs.amap.com/api/ios-location-sdk/changelog) 以上。